### PR TITLE
hardcode maven version

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -25,9 +25,10 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-
+      - name: Pick maven version
+        run: mvn wrapper:wrapper -Dmaven=3.8.6
       - name: Build project with Maven
-        run: mvn -B package
+        run: ./mvnw -B package
 
   publish-job:
     runs-on: ubuntu-latest
@@ -42,6 +43,8 @@ jobs:
         with:
           distribution: corretto
           java-version: 11
+      - name: Pick maven version
+        run: mvn wrapper:wrapper -Dmaven=3.8.6
       - name: Bump Version
         id: bump
         uses: Plugily-Projects/maven-version-bump-action@v8
@@ -49,10 +52,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-version-bump: true
           git-committer: 'BOT'
-      - run: mvn -B package -DskipTests
+      - run: ./mvnw -B package -DskipTests
       - run: mkdir staging && cp target/*jar-with-dependencies.jar staging
       - name: Publish package
-        run: mvn --batch-mode deploy
+        run: ./mvnw --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.mvn/wrapper/maven-wrapper.jar

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=11.0.17-amzn
+maven=3.8.6

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You will need to set your package name and repository configuration in `pom.xml`
 
 Version numbers will be bumped on every merge to the main branch. By default, this will increment the snapshot number, but you can also add `#major`, `#minor`, or `#patch` to a commit message if you are changing something more substantial
 
-This repository uses Java 11. You can override this by updating the configuration in:
+This repository uses Java 11 and Maven 3.8.6. You can override this by updating the configuration in:
 
 * pom.xml
 * .github/workflows/maven.yaml (in multiple places)


### PR DESCRIPTION
Required because of a GitHub Packages bug in maven 3.9, but also protects against other future bugs